### PR TITLE
Locale and Build fixes 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 jdk:
@@ -11,4 +13,4 @@ cache:
 install: true
 
 script:
-  - mvn -U -C -Dtyrus.test.container.client=org.glassfish.tyrus.container.grizzly.client.GrizzlyClientContainer -Pbundles -Pjvnet-nexus-releases clean install
+  - mvn -U -c -Dtyrus.test.container.client=org.glassfish.tyrus.container.grizzly.client.GrizzlyClientContainer -Pbundles -Pjvnet-nexus-releases clean install

--- a/containers/jdk-client/src/test/java/org/glassfish/tyrus/container/jdk/client/UnknownHostTest.java
+++ b/containers/jdk-client/src/test/java/org/glassfish/tyrus/container/jdk/client/UnknownHostTest.java
@@ -16,6 +16,8 @@
 
 package org.glassfish.tyrus.container.jdk.client;
 
+import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.websocket.ContainerProvider;
@@ -33,6 +35,10 @@ public class UnknownHostTest {
 
     private static final Logger LOG = Logger.getLogger(UnknownHostTest.class.getName());
 
+    @Before
+    public void assumeUnixOs() {
+        Assume.assumeTrue(isUnixOs());
+    }
 
     @Test
     public void testIncreaseFileDescriptorsOnTyrusImplementationInCaseOfUnresolvedAddressException() throws Exception {
@@ -80,6 +86,11 @@ public class UnknownHostTest {
     private long getOpenFileDescriptorCount() {
         return (((com.sun.management.UnixOperatingSystemMXBean) java.lang.management.ManagementFactory
                 .getOperatingSystemMXBean()).getOpenFileDescriptorCount());
+    }
+
+    private boolean isUnixOs() {
+        return (java.lang.management.ManagementFactory
+                .getOperatingSystemMXBean() instanceof com.sun.management.UnixOperatingSystemMXBean);
     }
 
     private static class WebSocketClientEndpoint extends Endpoint {

--- a/core/src/main/java/org/glassfish/tyrus/core/Utils.java
+++ b/core/src/main/java/org/glassfish/tyrus/core/Utils.java
@@ -452,15 +452,15 @@ public class Utils {
      * @throws ParseException if the specified string cannot be parsed in neither of all three HTTP date formats.
      */
     public static Date parseHttpDate(String stringValue) throws ParseException {
-        SimpleDateFormat formatRfc1123 = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz");
+        SimpleDateFormat formatRfc1123 = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH);
         try {
             return formatRfc1123.parse(stringValue);
         } catch (ParseException e) {
-            SimpleDateFormat formatRfc1036 = new SimpleDateFormat("EEE, dd-MMM-yy HH:mm:ss zzz");
+            SimpleDateFormat formatRfc1036 = new SimpleDateFormat("EEE, dd-MMM-yy HH:mm:ss zzz", Locale.ENGLISH);
             try {
                 return formatRfc1036.parse(stringValue);
             } catch (ParseException e1) {
-                SimpleDateFormat formatAnsiCAsc = new SimpleDateFormat("EEE MMM d HH:mm:ss yyyy");
+                SimpleDateFormat formatAnsiCAsc = new SimpleDateFormat("EEE MMM d HH:mm:ss yyyy", Locale.ENGLISH);
                 return formatAnsiCAsc.parse(stringValue);
             }
         }

--- a/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/RetryAfterTest.java
+++ b/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/RetryAfterTest.java
@@ -19,6 +19,7 @@ package org.glassfish.tyrus.test.e2e.non_deployable;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Date;
+import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -72,7 +73,7 @@ public class RetryAfterTest extends TestContainer {
             server = startServer(RetryAfterEchoEndpoint.class);
 
             testRetryAfter(
-                    new java.text.SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz")
+                    new java.text.SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.ENGLISH)
                             .format(new Date(System.currentTimeMillis() + 1000)));
 
         } finally {


### PR DESCRIPTION
This pull-request resolves #622 

parse HTTP date is now working on JVMs with non-EN default locales.

Furthermore the build succeeds on non Unix-Systems (e.g. Windows) (fixed Unit-Test by introducing an assumption)