### PR TITLE
Specify Trusty to be used for Tyrus. Xenial does not support JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 jdk:


### PR DESCRIPTION
Signed-off-by: Jan Supol <jan.supol@oracle.com>