### PR TITLE
Close connection after TLS timeout or error

### DIFF
--- a/containers/grizzly-client/src/main/java/org/glassfish/tyrus/container/grizzly/client/GrizzlyClientSocket.java
+++ b/containers/grizzly-client/src/main/java/org/glassfish/tyrus/container/grizzly/client/GrizzlyClientSocket.java
@@ -376,8 +376,10 @@ public class GrizzlyClientSocket {
                     try {
                         sslHandshakeFuture.get(timeoutMs, TimeUnit.MILLISECONDS);
                     } catch (ExecutionException e) {
+                        closeTransport(privateTransport);
                         throw new DeploymentException("SSL handshake has failed", e.getCause());
                     } catch (Exception e) {
+                        closeTransport(privateTransport);
                         throw new DeploymentException(String.format("Connection to '%s' failed.", requestURI),
                                                       e.getCause());
                     }


### PR DESCRIPTION
This is to fix #675 that was causing connections leak it is not closed after TLS timeout.
This can be recreated with a Tomcat with max-connection to 1.
Run two websocket clients:
  1. 1st client connects and onOpen() will be called.
  2. 2nd client still connects but stuck at Tomcat waiting for available connection
  3. Wait 30 seconds 2nd client will get DeploymentException. But underlying connection not closed.
  4. Stop 1st client to release the connection
  5. 2nd client onOpen() will be called because the TLS now goes through

After the fix, step 3 will close the connection. Step 5 will not happen.
