### PR TITLE
Feature/installed extensions

### DIFF
--- a/client/src/main/java/org/glassfish/tyrus/client/ClientManager.java
+++ b/client/src/main/java/org/glassfish/tyrus/client/ClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -528,7 +528,8 @@ public class ClientManager extends BaseContainer implements WebSocketContainer {
                         } else if ((((Class<?>) o).getAnnotation(ClientEndpoint.class) != null)) {
                             endpoint = AnnotatedEndpoint
                                     .fromClass((Class) o, componentProvider, false, incomingBufferSize, collector,
-                                               EndpointEventListener.NO_OP);
+                                               EndpointEventListener.NO_OP,
+                                               getInstalledExtensions());
                             config = (ClientEndpointConfig) ((AnnotatedEndpoint) endpoint).getEndpointConfig();
                         } else {
                             collector.addException(new DeploymentException(String.format(
@@ -539,7 +540,8 @@ public class ClientManager extends BaseContainer implements WebSocketContainer {
                         }
                     } else {
                         endpoint = AnnotatedEndpoint
-                                .fromInstance(o, componentProvider, false, incomingBufferSize, collector);
+                                .fromInstance(o, componentProvider, false, incomingBufferSize, collector,
+                                getInstalledExtensions());
                         config = (ClientEndpointConfig) ((AnnotatedEndpoint) endpoint).getEndpointConfig();
                     }
 
@@ -754,7 +756,6 @@ public class ClientManager extends BaseContainer implements WebSocketContainer {
     @Override
     public Set<Extension> getInstalledExtensions() {
         if (webSocketContainer == null) {
-            // TODO
             return Collections.emptySet();
         } else {
             return webSocketContainer.getInstalledExtensions();

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2011, 2017 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2011, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/core/src/main/java/org/glassfish/tyrus/core/TyrusServerEndpointConfig.java
+++ b/core/src/main/java/org/glassfish/tyrus/core/TyrusServerEndpointConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -115,7 +115,7 @@ public interface TyrusServerEndpointConfig extends ServerEndpointConfig {
             );
         }
 
-        private Builder(Class endpointClass, String path) {
+        private Builder(Class<?> endpointClass, String path) {
             if (endpointClass == null) {
                 throw new IllegalArgumentException("endpointClass cannot be null");
             }

--- a/core/src/main/java/org/glassfish/tyrus/core/TyrusWebSocketEngine.java
+++ b/core/src/main/java/org/glassfish/tyrus/core/TyrusWebSocketEngine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,6 +17,7 @@
 package org.glassfish.tyrus.core;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -591,7 +592,7 @@ public class TyrusWebSocketEngine implements WebSocketEngine {
         EndpointEventListenerWrapper endpointEventListenerWrapper = new EndpointEventListenerWrapper();
         AnnotatedEndpoint endpoint = AnnotatedEndpoint
                 .fromClass(endpointClass, componentProviderService, true, incomingBufferSize, collector,
-                           endpointEventListenerWrapper);
+                           endpointEventListenerWrapper, webSocketContainer.getInstalledExtensions());
         EndpointConfig config = endpoint.getEndpointConfig();
 
         TyrusEndpointWrapper endpointWrapper =
@@ -644,7 +645,7 @@ public class TyrusWebSocketEngine implements WebSocketEngine {
 
             final AnnotatedEndpoint endpoint = AnnotatedEndpoint
                     .fromClass(endpointClass, componentProviderService, true, incomingBufferSize, collector,
-                               endpointEventListenerWrapper);
+                               endpointEventListenerWrapper, webSocketContainer.getInstalledExtensions());
             final EndpointConfig config = endpoint.getEndpointConfig();
 
             endpointWrapper = new TyrusEndpointWrapper(

--- a/server/src/main/java/org/glassfish/tyrus/server/TyrusServerContainer.java
+++ b/server/src/main/java/org/glassfish/tyrus/server/TyrusServerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -317,9 +317,6 @@ public abstract class TyrusServerContainer extends BaseContainer implements Serv
 
     @Override
     public Set<Extension> getInstalledExtensions() {
-        // TODO
-        // return Collections.unmodifiableSet(new HashSet<String>(configuration.parseExtensionsHeader()));
-
         return Collections.emptySet();
     }
 


### PR DESCRIPTION
I've had a bash at this under the following assumptions:
* Anything using `ServerEndpointConfig` _could_ use the extensions within `WebsocketContainer#getInstalledExtensions` if they wished therefore left untouched,
* Annotated server endpoints do not get that luxury but they could filter out extensions using `ServerEndpointConfig.Configurator#getNegotiatedExtensions`,
* Annotated client endpoints can filter out the extensions by using `ClientEndpointConfig.Configurator#beforeRequest`, a bit clunky but should prevent the server from negotiating.

Build here: [#671171750](https://travis-ci.org/github/dansiviter/tyrus/builds/671171750)

Also, not sure which branch to aim for so put `master`.