### PR TITLE
Lambda MessageHandler support

### DIFF
--- a/core/src/main/java/org/glassfish/tyrus/core/MessageHandlerManager.java
+++ b/core/src/main/java/org/glassfish/tyrus/core/MessageHandlerManager.java
@@ -301,6 +301,10 @@ public class MessageHandlerManager {
         }
     }
 
+    Map<Class<?>, MessageHandler> getRegisteredHandlers() {
+        return new HashMap<>(registeredHandlers);
+    }
+
     /**
      * Get all successfully registered {@link MessageHandler}s.
      *
@@ -308,14 +312,14 @@ public class MessageHandlerManager {
      */
     public Set<MessageHandler> getMessageHandlers() {
         if (messageHandlerCache == null) {
-            messageHandlerCache = Collections.unmodifiableSet(new HashSet<MessageHandler>(registeredHandlers.values()));
+            messageHandlerCache = Collections.unmodifiableSet(new HashSet<>(registeredHandlers.values()));
         }
 
         return messageHandlerCache;
     }
 
     public List<Map.Entry<Class<?>, MessageHandler>> getOrderedWholeMessageHandlers() {
-        List<Map.Entry<Class<?>, MessageHandler>> result = new ArrayList<Map.Entry<Class<?>, MessageHandler>>();
+        List<Map.Entry<Class<?>, MessageHandler>> result = new ArrayList<>();
         for (final Map.Entry<Class<?>, MessageHandler> entry : registeredHandlers.entrySet()) {
             if (entry.getValue() instanceof MessageHandler.Whole) {
                 result.add(entry);
@@ -325,7 +329,7 @@ public class MessageHandlerManager {
         return result;
     }
 
-    static Class<?> getHandlerType(MessageHandler handler) {
+    private static Class<?> getHandlerType(MessageHandler handler) {
         Class<?> root;
         if (handler instanceof AsyncMessageHandler) {
             return ((AsyncMessageHandler) handler).getType();

--- a/core/src/test/java/org/glassfish/tyrus/core/TyrusSessionTest.java
+++ b/core/src/test/java/org/glassfish/tyrus/core/TyrusSessionTest.java
@@ -294,7 +294,6 @@ public class TyrusSessionTest {
     public void multiplePongHandlersAsync() {
         Session session = createSession(endpointWrapper);
 
-
         session.addMessageHandler(new MessageHandler.Partial<PongMessage>() {
             @Override
             public void onMessage(PongMessage message, boolean last) {
@@ -311,7 +310,6 @@ public class TyrusSessionTest {
     @Test(expected = IllegalStateException.class)
     public void multipleBasicDecodableAsync() {
         Session session = createSession(endpointWrapper);
-
 
         session.addMessageHandler(new MessageHandler.Partial<TyrusSessionTest>() {
             @Override
@@ -359,7 +357,6 @@ public class TyrusSessionTest {
     public void removeHandlers() {
         Session session = createSession(endpointWrapper);
 
-
         final MessageHandler.Partial<String> handler1 = new MessageHandler.Partial<String>() {
             @Override
             public void onMessage(String message, boolean last) {
@@ -406,6 +403,44 @@ public class TyrusSessionTest {
         assertFalse(session1.getId().equals(session2.getId()));
         assertFalse(session1.getId().equals(session3.getId()));
         assertFalse(session2.getId().equals(session3.getId()));
+    }
+
+    @Test
+    public void getLambdaHandlers() {
+        Session session = createSession(endpointWrapper);
+
+        final MessageHandler.Partial<String> handler1 = this::stringPartialHandler;
+        final MessageHandler.Whole<ByteBuffer> handler2 = this::bytesHandler;
+        final MessageHandler.Whole<PongMessage> handler3 = this::pongHandler;
+
+        session.addMessageHandler(String.class, handler1);
+        session.addMessageHandler(ByteBuffer.class, handler2);
+        session.addMessageHandler(PongMessage.class, handler3);
+
+        assertTrue(session.getMessageHandlers().contains(handler1));
+        assertTrue(session.getMessageHandlers().contains(handler2));
+        assertTrue(session.getMessageHandlers().contains(handler3));
+
+        session.removeMessageHandler(handler3);
+
+        assertTrue(session.getMessageHandlers().contains(handler1));
+        assertTrue(session.getMessageHandlers().contains(handler2));
+        assertFalse(session.getMessageHandlers().contains(handler3));
+
+        session.removeMessageHandler(handler2);
+
+        assertTrue(session.getMessageHandlers().contains(handler1));
+        assertFalse(session.getMessageHandlers().contains(handler2));
+        assertFalse(session.getMessageHandlers().contains(handler3));
+    }
+
+    private void stringPartialHandler(String message, boolean last) {
+    }
+
+    private void bytesHandler(ByteBuffer message) {
+    }
+
+    private void pongHandler(PongMessage message) {
     }
 
 


### PR DESCRIPTION
Due to type erasure of lambdas we have to rely on the `Class` instance passed to the `#addMessageHandler(Class, MessageHandler.Whole)` and `#addMessageHandler(Class, MessageHandler.Partial)`. I've also removed some superfluous generics markup.