### PR TITLE
Make WebSocketAddOn constructor public 

### DIFF
--- a/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/WebSocketAddOn.java
+++ b/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/WebSocketAddOn.java
@@ -36,7 +36,7 @@ public class WebSocketAddOn implements AddOn {
     private final ServerContainer serverContainer;
     private final String contextPath;
 
-    WebSocketAddOn(ServerContainer serverContainer, String contextPath) {
+    public WebSocketAddOn(ServerContainer serverContainer, String contextPath) {
         this.serverContainer = serverContainer;
         this.contextPath = contextPath;
     }


### PR DESCRIPTION
To allow other developers use WSS protocol easily on their own GrizzlyServerContainer alternative, WebSocketAddOn constructor should also be public so it can be instantiated from different package name than "org.glassfish.tyrus.container.grizzly.server".