### PR TITLE
remove potential test order dependency

### DIFF
--- a/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/ExtendedExtensionTest.java
+++ b/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/ExtendedExtensionTest.java
@@ -58,6 +58,7 @@ public class ExtendedExtensionTest extends TestContainer {
 
     @Test
     public void extendedExtensionTest() throws DeploymentException {
+        EXTENDED_EXTENSION = new MyExtendedExtension();
 
         Server server = startServer(ExtendedExtensionApplicationConfig.class);
         final CountDownLatch messageLatch = new CountDownLatch(1);
@@ -123,7 +124,7 @@ public class ExtendedExtensionTest extends TestContainer {
         }
     }
 
-    private static final MyExtendedExtension EXTENDED_EXTENSION = new MyExtendedExtension();
+    private static MyExtendedExtension EXTENDED_EXTENSION;
 
     public static class ExtendedExtensionEndpoint extends Endpoint {
 


### PR DESCRIPTION
The static EXTENDED_EXTENSION variable is shared among tests. Reinitializing it before the test run can avoid potential test order dependency.