### PR TITLE
Fixed class loader leaks

### DIFF
--- a/containers/servlet/src/main/java/org/glassfish/tyrus/servlet/TyrusServletFilter.java
+++ b/containers/servlet/src/main/java/org/glassfish/tyrus/servlet/TyrusServletFilter.java
@@ -65,7 +65,7 @@ import org.glassfish.tyrus.spi.Writer;
 class TyrusServletFilter implements Filter, HttpSessionListener {
 
     private static final Logger LOGGER = Logger.getLogger(TyrusServletFilter.class.getName());
-    private final TyrusWebSocketEngine engine;
+    private TyrusWebSocketEngine engine;
     private final boolean wsadlEnabled;
 
     // I don't like this map, but it seems like it is necessary. I am forced to handle subscriptions
@@ -303,5 +303,7 @@ class TyrusServletFilter implements Filter, HttpSessionListener {
     public void destroy() {
         serverContainer.stop();
         engine.getApplicationEventListener().onApplicationDestroyed();
+        serverContainer = null;
+        engine = null;
     }
 }


### PR DESCRIPTION
Fixes #726 

No longer hangs on to context class loaders and user application classes when app is undeployed
Tracked this down over multiple passes with VisualVM heap dumps to find out GC roots.

- refactored anonymous inner class into `TyrusServerContainerImpl` so the former doesn't hand on to the `ServletContext` and thus application's class loader
- reset `engine` and `serverContainer` to null after `TyrusServletFilter` is destroyed, so they do not hang on to user application classes when application is unloded.