### PR TITLE
Fix race condition causing unexpected idle disconnections

### DIFF
--- a/core/src/main/java/org/glassfish/tyrus/core/TyrusSession.java
+++ b/core/src/main/java/org/glassfish/tyrus/core/TyrusSession.java
@@ -482,9 +482,8 @@ public class TyrusSession implements DistributedSession {
     }
 
     void restartIdleTimeoutExecutor() {
-        cancelIdleTimeoutExecutor();
-
         synchronized (idleTimeoutLock) {
+            cancelIdleTimeoutExecutor();
             idleTimeoutFuture =
                     service.schedule(new IdleTimeoutCommand(), this.getMaxIdleTimeout(), TimeUnit.MILLISECONDS);
         }


### PR DESCRIPTION
This issue may appear when 'send[data]' methods are triggered from different threads. As a result threads race appears between cancelIdleTimeoutExecutor and scheduling new idle task. Example of race:
1. Thread 1 cancels task
2. Thread 2 waits until thread 1 will finish
3. Thread 1 finishes
4. Thread 2 tries to cancel already cancelled task and leaves synchronized block
5. Thread 1 schedules new idle task
6. Thread 2 schedules another idle task, the first is overwritten and never cancelled. As a result disconnection is triggered precisely after set idle timeout passes.



I would appreciate if this fix will be added to the version responsible for Java 1.x implementation, since this is one we still use in our internal project.