### PR TITLE
Fix websocket redeployment

### DIFF
--- a/containers/servlet/src/main/java/org/glassfish/tyrus/servlet/TyrusServletContainerInitializer.java
+++ b/containers/servlet/src/main/java/org/glassfish/tyrus/servlet/TyrusServletContainerInitializer.java
@@ -68,6 +68,11 @@ public class TyrusServletContainerInitializer implements ServletContainerInitial
             return;
         }
 
+        if (ctx.getAttribute(ServerContainer.class.getName()) != null) {
+            // Already initialized
+            return;
+        }
+
         classes.removeAll(FILTERED_CLASSES);
 
         final Integer incomingBufferSize = getIntContextParam(ctx, TyrusHttpUpgradeHandler.FRAME_BUFFER_SIZE);


### PR DESCRIPTION
See https://github.com/payara/Payara/issues/5640

FacesInitializer and TyrusServletContainerInitializer both attempt to initialize a filter, with only FacesInitializer checking if the filter is already present. The order that these happen in is undefined, it's just whatever order the initializers are found in (this order only changes on server restart, not on application redeploy) - this causes the redeployment to fail 