### PR TITLE
Use Windows system certificate store if requested by system properties

### DIFF
--- a/client/src/main/java/org/glassfish/tyrus/client/SslContextConfigurator.java
+++ b/client/src/main/java/org/glassfish/tyrus/client/SslContextConfigurator.java
@@ -578,6 +578,17 @@ public class SslContextConfigurator {
             TrustManagerFactory trustManagerFactory = null;
             KeyManagerFactory keyManagerFactory = null;
 
+            if ("SunMSCAPI".equals(System.getProperty(TRUST_STORE_PROVIDER))) {
+                try {
+                    KeyStore keyStore = KeyStore.getInstance(System.getProperty(TRUST_STORE_TYPE), "SunMSCAPI");
+                    keyStore.load(null, null);
+                    trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                    trustManagerFactory.init(keyStore);
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
             if (keyStoreBytes != null || keyStoreFile != null) {
                 try {
                     KeyStore keyStore;

--- a/containers/jdk-client/src/main/java/org/glassfish/tyrus/container/jdk/client/SslContextConfigurator.java
+++ b/containers/jdk-client/src/main/java/org/glassfish/tyrus/container/jdk/client/SslContextConfigurator.java
@@ -524,6 +524,17 @@ public class SslContextConfigurator {
 
         try {
             TrustManagerFactory trustManagerFactory = null;
+            if ("SunMSCAPI".equals(System.getProperty(TRUST_STORE_PROVIDER))) {
+                try {
+                    KeyStore keyStore = KeyStore.getInstance(System.getProperty(TRUST_STORE_TYPE), "SunMSCAPI");
+                    keyStore.load(null, null);
+                    trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+                    trustManagerFactory.init(keyStore);
+                } catch (Throwable e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
             KeyManagerFactory keyManagerFactory = null;
 
             if (keyStoreBytes != null || keyStoreFile != null) {


### PR DESCRIPTION
Not sure if this is the most elegant way to handle this, but if the user has selected SunMSCAPI as the trust store provider, they probably expect Tyrus to load Windows system certificate store (=work with enterprise root signed ssl certificates)