### PR TITLE
bugfix: found another case of TyrusHttpUpgradeHandler holding on to C…

### DIFF
--- a/containers/servlet/src/main/java/org/glassfish/tyrus/servlet/TyrusHttpUpgradeHandler.java
+++ b/containers/servlet/src/main/java/org/glassfish/tyrus/servlet/TyrusHttpUpgradeHandler.java
@@ -281,6 +281,7 @@ public class TyrusHttpUpgradeHandler implements HttpUpgradeHandler, ReadListener
                 connection.close(new CloseReason(CloseReason.CloseCodes.getCloseCode(closeCode), closeReason));
                 closed = true;
                 wc.close();
+                connection = null;
                 upgradeInfo = null;
             } catch (Exception e) {
                 LOGGER.log(Level.CONFIG, e.getMessage(), e);
@@ -294,6 +295,7 @@ public class TyrusHttpUpgradeHandler implements HttpUpgradeHandler, ReadListener
                 connection.close(CloseReasons.create(CloseReason.CloseCodes.getCloseCode(closeCode), closeReason));
                 closed = true;
                 wc.close();
+                connection = null;
                 upgradeInfo = null;
             } catch (Exception e) {
                 LOGGER.log(Level.CONFIG, e.getMessage(), e);


### PR DESCRIPTION
…lassLoader, via `Connection` instance
after session is closed causing a memory and ClassLoader leak in application servers

Continuation of #943

Unfortunately testing revealed that there is another place where ClassLoader is referenced.

i have run a full battery of tests now and the ClassLoader is finally released.

Sorry about the multiple PRs.