### PR TITLE
Allow re-use by making these public with a public constructor

### DIFF
--- a/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/GrizzlyServerFilter.java
+++ b/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/GrizzlyServerFilter.java
@@ -74,7 +74,7 @@ import org.glassfish.grizzly.utils.Charsets;
  * @author Alexey Stashok
  * @author Pavel Bucek
  */
-class GrizzlyServerFilter extends BaseFilter {
+public class GrizzlyServerFilter extends BaseFilter {
 
     private static final Logger LOGGER = Grizzly.logger(GrizzlyServerFilter.class);
 

--- a/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/WebSocketAddOn.java
+++ b/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/WebSocketAddOn.java
@@ -36,7 +36,7 @@ public class WebSocketAddOn implements AddOn {
     private final ServerContainer serverContainer;
     private final String contextPath;
 
-    WebSocketAddOn(ServerContainer serverContainer, String contextPath) {
+    public WebSocketAddOn(ServerContainer serverContainer, String contextPath) {
         this.serverContainer = serverContainer;
         this.contextPath = contextPath;
     }


### PR DESCRIPTION
WebSocketAddOn should definitely be public in a way that allows re-use. We construct our grizzly server via spring, with a few modification, and I would like to be able to add Tyrus without having to create my own versions of WebSocketAddOn and/or GrizzlyServerFilter. We currently do both, and although add-on is simple, GrizzlyServerFilter is not, and you are just enforcing a pain point for no reason I can discern. This is an open source project. I pould like to make WebSocketAddOn re-usable by providing a public constructor on this already public class, and, for good measure, making GrizzlyServerFilter a public class to go with its already public constructor. This helps us greatly and I can see no harm.