### PR TITLE
Allow re-use by making these public with a public constructor

### DIFF
--- a/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/GrizzlyServerFilter.java
+++ b/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/GrizzlyServerFilter.java
@@ -74,7 +74,7 @@ import org.glassfish.grizzly.utils.Charsets;
  * @author Alexey Stashok
  * @author Pavel Bucek
  */
-class GrizzlyServerFilter extends BaseFilter {
+public class GrizzlyServerFilter extends BaseFilter {
 
     private static final Logger LOGGER = Grizzly.logger(GrizzlyServerFilter.class);
 

--- a/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/WebSocketAddOn.java
+++ b/containers/grizzly-server/src/main/java/org/glassfish/tyrus/container/grizzly/server/WebSocketAddOn.java
@@ -36,7 +36,7 @@ public class WebSocketAddOn implements AddOn {
     private final ServerContainer serverContainer;
     private final String contextPath;
 
-    WebSocketAddOn(ServerContainer serverContainer, String contextPath) {
+    public WebSocketAddOn(ServerContainer serverContainer, String contextPath) {
         this.serverContainer = serverContainer;
         this.contextPath = contextPath;
     }


### PR DESCRIPTION
Allow public construction on classes that can be used to configure Tyrus/Grizzly programmatically. I can see maybe wanting GrizzlyServerFilter as a non-public helper, although, I think this is central enough that you should be proud to make it available. WebSocketAddOn just needs to be public for the sake of creating and configuring a grizzly server.