### PR TITLE
Updated Jetty, GlassFish, Grizzly and fixes to pass all tests locally

### DIFF
--- a/bundles/client/pom.xml
+++ b/bundles/client/pom.xml
@@ -66,7 +66,7 @@
                             jakarta.websocket;version=${apijar.bundle.version}
                         </Export-Package>
                         <Import-Package>
-                            org.glassfish.grizzly.*;version="[3.0,5)",*
+                            org.glassfish.grizzly.*;version="3",*
                         </Import-Package>
                     </instructions>
                     <unpackBundle>true</unpackBundle>

--- a/bundles/websocket-ri-bundle/pom.xml
+++ b/bundles/websocket-ri-bundle/pom.xml
@@ -246,9 +246,7 @@
                             jakarta.enterprise.context.spi;version="[3.0,5)",
                             jakarta.enterprise.inject.spi;version="[3.0,5)",
                             jakarta.xml.bind.*;version="[3.0,5)",
-                            org.glassfish.grizzly.*;version="[3.0,5)",
-<!--                            org.glassfish.grizzly.http.server.*;version=${grizzly.version}-->
-<!--                            org.glassfish.grizzly.*;version=${grizzly.version},-->
+                            org.glassfish.grizzly.*;version="3",
                             *
                         </Import-Package>
                     </instructions>

--- a/containers/grizzly-client/pom.xml
+++ b/containers/grizzly-client/pom.xml
@@ -61,7 +61,7 @@
                     <instructions>
                         <Export-Package>org.glassfish.tyrus.container.grizzly.client.*;version=${project.version}
                         </Export-Package>
-                        <Import-Package>org.glassfish.grizzly.*;version="[3.0,5)",*</Import-Package>
+                        <Import-Package>org.glassfish.grizzly.*;version="3",*</Import-Package>
                     </instructions>
                     <unpackBundle>true</unpackBundle>
                 </configuration>

--- a/containers/grizzly-server/pom.xml
+++ b/containers/grizzly-server/pom.xml
@@ -62,7 +62,7 @@
                         </Export-Package>
                         <Import-Package>
                             jakarta.xml.bind.*;version="[3.0,5)",
-                            org.glassfish.grizzly.*;version="[3.0,5)",
+                            org.glassfish.grizzly.*;version="3",
                             *
                         </Import-Package>
                     </instructions>

--- a/ext/monitoring-jmx/pom.xml
+++ b/ext/monitoring-jmx/pom.xml
@@ -70,7 +70,7 @@
                 <configuration>
                     <instructions>
                         <Export-Package>org.glassfish.tyrus.ext.monitoring.jmx.*;version=${project.version}</Export-Package>
-                        <Import-Package>org.glassfish.grizzly.*;version="[3.0,5)",*</Import-Package>
+                        <Import-Package>org.glassfish.grizzly.*;version="3",*</Import-Package>
                     </instructions>
                     <unpackBundle>true</unpackBundle>
                 </configuration>

--- a/ext/monitoring-jmx/src/test/java/org/glassfish/tyrus/ext/monitoring/jmx/MessageStatisticsTest.java
+++ b/ext/monitoring-jmx/src/test/java/org/glassfish/tyrus/ext/monitoring/jmx/MessageStatisticsTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -51,6 +52,9 @@ import static org.junit.Assert.fail;
  * @author Petr Janouch
  */
 public class MessageStatisticsTest extends TestContainer {
+
+    private final int serverPort1 = getPort();
+    private final int serverPort2 = serverPort1 + 1;
 
     @ServerEndpoint("/jmxStatisticsServerEndpoint1")
     public static class ServerEndpoint1 {
@@ -170,7 +174,7 @@ public class MessageStatisticsTest extends TestContainer {
                     new TestApplicationEventListener(applicationMonitor, null, null, messageSentLatch,
                                                      messageReceivedLatch, null);
             server1Properties.put(ApplicationEventListener.APPLICATION_EVENT_LISTENER, application1EventListener);
-            server1 = new Server("localhost", 8025, "/jmxTestApp", server1Properties, ServerEndpoint1.class,
+            server1 = new Server("localhost", serverPort1, "/jmxTestApp", server1Properties, ServerEndpoint1.class,
                                  ServerEndpoint2.class);
             server1.start();
 
@@ -179,28 +183,28 @@ public class MessageStatisticsTest extends TestContainer {
                     new TestApplicationEventListener(new ApplicationMonitor(monitorOnSessionLevel), null, null,
                                                      messageSentLatch, messageReceivedLatch, null);
             server2Properties.put(ApplicationEventListener.APPLICATION_EVENT_LISTENER, application2EventListener);
-            server2 = new Server("localhost", 8026, "/jmxTestApp2", server2Properties, ServerEndpoint2.class,
+            server2 = new Server("localhost", serverPort2, "/jmxTestApp2", server2Properties, ServerEndpoint2.class,
                                  ServerEndpoint3.class);
             server2.start();
 
             ClientManager client = createClient();
             Session session1 = client.connectToServer(AnnotatedClientEndpoint.class,
-                                                      new URI("ws", null, "localhost", 8025,
+                                                      new URI("ws", null, "localhost", serverPort1,
                                                               "/jmxTestApp/jmxStatisticsServerEndpoint1", null, null));
             Session session2 = client.connectToServer(AnnotatedClientEndpoint.class,
-                                                      new URI("ws", null, "localhost", 8025,
+                                                      new URI("ws", null, "localhost", serverPort1,
                                                               "/jmxTestApp/jmxStatisticsServerEndpoint2", null, null));
             Session session3 = client.connectToServer(AnnotatedClientEndpoint.class,
-                                                      new URI("ws", null, "localhost", 8025,
+                                                      new URI("ws", null, "localhost", serverPort1,
                                                               "/jmxTestApp/jmxStatisticsServerEndpoint2", null, null));
             Session session4 = client.connectToServer(AnnotatedClientEndpoint.class,
-                                                      new URI("ws", null, "localhost", 8026,
+                                                      new URI("ws", null, "localhost", serverPort2,
                                                               "/jmxTestApp2/jmxStatisticsServerEndpoint2", null, null));
             Session session5 = client.connectToServer(AnnotatedClientEndpoint.class,
-                                                      new URI("ws", null, "localhost", 8026,
+                                                      new URI("ws", null, "localhost", serverPort2,
                                                               "/jmxTestApp2/jmxStatisticsServerEndpoint3", null, null));
             Session session6 = client.connectToServer(AnnotatedClientEndpoint.class,
-                                                      new URI("ws", null, "localhost", 8026,
+                                                      new URI("ws", null, "localhost", serverPort2,
                                                               "/jmxTestApp2/jmxStatisticsServerEndpoint3", null, null));
 
             session1.getBasicRemote().sendText(getText(1));

--- a/ext/monitoring-jmx/src/test/java/org/glassfish/tyrus/ext/monitoring/jmx/RegisteredEndpointsTest.java
+++ b/ext/monitoring-jmx/src/test/java/org/glassfish/tyrus/ext/monitoring/jmx/RegisteredEndpointsTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -46,6 +47,9 @@ import static org.junit.Assert.fail;
  */
 public class RegisteredEndpointsTest extends TestContainer {
 
+    private final int serverPort1 = getPort();
+    private final int serverPort2 = serverPort1 + 1;
+
     @ServerEndpoint("/jmxServerEndpoint1")
     public static class AnnotatedServerEndpoint1 {
     }
@@ -66,14 +70,14 @@ public class RegisteredEndpointsTest extends TestContainer {
             Map<String, Object> server1Properties = new HashMap<String, Object>();
             ApplicationEventListener application1EventListener = new SessionAwareApplicationMonitor();
             server1Properties.put(ApplicationEventListener.APPLICATION_EVENT_LISTENER, application1EventListener);
-            server1 = new Server("localhost", 8025, "/jmxTestApp", server1Properties, AnnotatedServerEndpoint1.class,
+            server1 = new Server("localhost", serverPort1, "/jmxTestApp", server1Properties, AnnotatedServerEndpoint1.class,
                                  AnnotatedServerEndpoint2.class);
             server1.start();
 
             Map<String, Object> server2Properties = new HashMap<String, Object>();
             server2Properties
                     .put(ApplicationEventListener.APPLICATION_EVENT_LISTENER, new SessionAwareApplicationMonitor());
-            server2 = new Server("localhost", 8026, "/jmxTestApp2", server2Properties, AnnotatedServerEndpoint2.class,
+            server2 = new Server("localhost", serverPort2, "/jmxTestApp2", server2Properties, AnnotatedServerEndpoint2.class,
                                  AnnotatedServerEndpoint3.class);
             server2.start();
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <!--
-
+    Copyright 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2011, 2025 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -127,7 +127,7 @@
         <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
         <maven.surefire.plugin.version>3.5.3</maven.surefire.plugin.version>
         <maven.war.plugin.version>3.4.0</maven.war.plugin.version>
-        <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>
+        <maven.bundle.plugin.version>6.0.0</maven.bundle.plugin.version>
         <cyclonedx.mvn.plugin.version>2.8.0</cyclonedx.mvn.plugin.version>
 
         <api_package>jakarta.websocket</api_package>
@@ -299,7 +299,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>${maven.bundle.plugin.version}</version> <!-- 5.1.5  brings dependencies on JDK packages -->
+                    <version>${maven.bundle.plugin.version}</version>
                     <extensions>true</extensions>
                     <configuration>
                         <instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <cdi-api.version>4.1.0</cdi-api.version>
         <ejb-api.version>4.0.1</ejb-api.version>
         <grizzly.version>4.0.2</grizzly.version>
-        <glassfish.version>8.0.0-JDK17-M6</glassfish.version>
+        <glassfish.version>7.1.0</glassfish.version>
         <inject.api.version>2.0.1</inject.api.version><!-- inherited from CDI, do not update unless inline with it -->
         <jaxb.api.version>4.0.2</jaxb.api.version>
         <jaxb.ri.version>4.0.5</jaxb.ri.version>
@@ -154,6 +154,8 @@
         <netbeans.hint.license>gf-cddl-gpl</netbeans.hint.license>
 
         <jar.updater.modules.skip>org.glassfish.tyrus.samples:*,*:*-project,*:tyrus-archetype*,*:*-documentation,org.glassfish.tyrus.tests:*e2e*,org.glassfish.tyrus.tests.servlet*:*,org.glassfish.tyrus.bundles:*,org.glassfish.tyrus.tests:*containers*</jar.updater.modules.skip>
+
+        <tyrus.test.port>8025</tyrus.test.port>
     </properties>
 
     <modules>

--- a/tests/e2e/jetty/auth-basic/pom.xml
+++ b/tests/e2e/jetty/auth-basic/pom.xml
@@ -25,7 +25,7 @@
         <version>2.2.99-SNAPSHOT</version>
     </parent>
 
-    <packaging>jar</packaging>
+    <packaging>war</packaging>
     <artifactId>tyrus-tests-e2e-auth-basic</artifactId>
 
     <name>Tyrus End-to-End Basic Auth Tests</name>
@@ -68,16 +68,6 @@
                             <config>${basedir}/src/main/resources/jetty/realm.properties</config>
                         </loginService>
                     </loginServices>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <!-- Exclude until Jetty plugin 10.0 final -->
-                        <exclude>org/glassfish/tyrus/tests/e2e/auth/basic/BasicAuthTest.java</exclude>
-                    </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/e2e/jetty/auth-digest/pom.xml
+++ b/tests/e2e/jetty/auth-digest/pom.xml
@@ -25,7 +25,7 @@
         <version>2.2.99-SNAPSHOT</version>
     </parent>
 
-    <packaging>jar</packaging>
+    <packaging>war</packaging>
     <artifactId>tyrus-tests-e2e-auth-digest</artifactId>
 
     <name>Tyrus End-to-End Digest Auth Tests</name>
@@ -68,16 +68,6 @@
                             <config>${basedir}/src/main/resources/jetty/realm.properties</config>
                         </loginService>
                     </loginServices>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <!-- Exclude until Jetty plugin 10.0 final -->
-                        <exclude>org/glassfish/tyrus/tests/e2e/auth/basic/DigestAuthTest.java</exclude>
-                    </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/tests/e2e/jetty/pom.xml
+++ b/tests/e2e/jetty/pom.xml
@@ -64,6 +64,9 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <properties>
+                <tyrus.test.port2>8026</tyrus.test.port2>
+            </properties>
             <build>
                 <pluginManagement>
                     <plugins>
@@ -73,14 +76,14 @@
                             <version>9.2.1.v20140609</version>
                             <configuration>
                                 <scanIntervalSeconds>10</scanIntervalSeconds>
-                                <stopPort>8026</stopPort>
+                                <stopPort>${tyrus.test.port2}</stopPort>
                                 <stopKey>STOP</stopKey>
                                 <stopWait>5</stopWait>
                                 <webApp>
                                     <contextPath>/</contextPath>
                                 </webApp>
                                 <httpConnector>
-                                    <port>8025</port>
+                                    <port>${tyrus.test.port}</port>
                                     <idleTimeout>10000</idleTimeout>
                                 </httpConnector>
                             </configuration>

--- a/tests/e2e/jetty/pom.xml
+++ b/tests/e2e/jetty/pom.xml
@@ -73,9 +73,8 @@
                         <plugin>
                             <groupId>org.eclipse.jetty</groupId>
                             <artifactId>jetty-maven-plugin</artifactId>
-                            <version>9.2.1.v20140609</version>
+                            <version>11.0.26</version>
                             <configuration>
-                                <scanIntervalSeconds>10</scanIntervalSeconds>
                                 <stopPort>${tyrus.test.port2}</stopPort>
                                 <stopKey>STOP</stopKey>
                                 <stopWait>5</stopWait>
@@ -94,10 +93,6 @@
                                     <goals>
                                         <goal>start</goal>
                                     </goals>
-                                    <configuration>
-                                        <scanIntervalSeconds>0</scanIntervalSeconds>
-                                        <daemon>true</daemon>
-                                    </configuration>
                                 </execution>
                                 <execution>
                                     <id>stop-jetty</id>

--- a/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/RedirectTest.java
+++ b/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/RedirectTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -61,10 +62,10 @@ import static org.junit.Assert.assertTrue;
  */
 public class RedirectTest extends TestContainer {
 
-    private static final int REDIRECTION_PORT = 8026;
-    private static final String REDIRECTION_URI = "ws://localhost:" + REDIRECTION_PORT;
+    private final int redirectionPort = getPort() + 1;
+    private final String redirectionUri = "ws://localhost:" + redirectionPort;
     private static final String REDIRECTION_PATH = "/redirect";
-    private static final List<HttpStatus> statuses =
+    private static final List<HttpStatus> STATUSES =
             Arrays.asList(HttpStatus.MULTIPLE_CHOICES_300, HttpStatus.MOVED_PERMANENTLY_301, HttpStatus.FOUND_302,
                           HttpStatus.SEE_OTHER_303, HttpStatus.TEMPORARY_REDIRECT_307,
                           HttpStatus.PERMANENT_REDIRECT_308);
@@ -81,7 +82,7 @@ public class RedirectTest extends TestContainer {
         try {
             server = startServer(RedirectedEchoEndpoint.class);
 
-            for (HttpStatus httpstatus : statuses) {
+            for (HttpStatus httpstatus : STATUSES) {
                 testRedirect(httpstatus);
             }
         } finally {
@@ -96,8 +97,8 @@ public class RedirectTest extends TestContainer {
         HttpServer httpServer = null;
         try {
 
-            httpServer = startHttpRedirectionServer(REDIRECTION_PORT, httpStatus,
-                                                    "ws://localhost:8025/redirect-echo/echo");
+            httpServer = startHttpRedirectionServer(redirectionPort, httpStatus,
+                "ws://localhost:" + getPort() + "/redirect-echo/echo");
 
             final ClientManager client = ClientManager.createClient();
             final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
@@ -124,7 +125,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH));
 
             messageLatch.await(1, TimeUnit.SECONDS);
             assertEquals(0, messageLatch.getCount());
@@ -142,7 +143,7 @@ public class RedirectTest extends TestContainer {
         try {
             server = startServer(RedirectedEchoEndpoint.class);
 
-            for (HttpStatus httpstatus : statuses) {
+            for (HttpStatus httpstatus : STATUSES) {
                 testRelativePath(httpstatus);
             }
         } finally {
@@ -156,18 +157,19 @@ public class RedirectTest extends TestContainer {
             AuthenticationException, DeploymentException {
         HttpServer httpServer = null;
         try {
-            httpServer = createHttpServer(REDIRECTION_PORT);
+            httpServer = createHttpServer(redirectionPort);
             httpServer.getServerConfiguration().addHttpHandler(
                     new RedirectHandler(httpStatus, REDIRECTION_PATH + 1), REDIRECTION_PATH + 0);
             httpServer.getServerConfiguration().addHttpHandler(
-                    new RedirectHandler(httpStatus, REDIRECTION_URI + REDIRECTION_PATH + 2), REDIRECTION_PATH + 1);
+                    new RedirectHandler(httpStatus, redirectionUri + REDIRECTION_PATH + 2), REDIRECTION_PATH + 1);
             httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, "/la/la/la/.././../.."
                     + REDIRECTION_PATH + 3), REDIRECTION_PATH + 2);
             httpServer.getServerConfiguration().addHttpHandler(
-                    new RedirectHandler(httpStatus, "http://127.0.0.1:8026" + REDIRECTION_PATH + 4),
-                    REDIRECTION_PATH + 3);
+                new RedirectHandler(httpStatus, "http://127.0.0.1:" + redirectionPort + REDIRECTION_PATH + 4),
+                REDIRECTION_PATH + 3);
             httpServer.getServerConfiguration().addHttpHandler(
-                    new RedirectHandler(httpStatus, "ws://localhost:8025/redirect-echo/echo"), REDIRECTION_PATH + 4);
+                new RedirectHandler(httpStatus, "ws://localhost:" + getPort() + "/redirect-echo/echo"),
+                REDIRECTION_PATH + 4);
             httpServer.start();
 
             final ClientManager client = createClient();
@@ -194,7 +196,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH + 0));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH + 0));
 
             messageLatch.await(1, TimeUnit.SECONDS);
             assertEquals(0, messageLatch.getCount());
@@ -224,8 +226,8 @@ public class RedirectTest extends TestContainer {
             AuthenticationException {
         HttpServer httpServer = null;
         try {
-            httpServer = startHttpRedirectionServer(REDIRECTION_PORT, httpStatus,
-                                                    "ws://localhost:8025/redirect-echo/echo");
+            httpServer = startHttpRedirectionServer(redirectionPort, httpStatus,
+                "ws://localhost:" + getPort() + "/redirect-echo/echo");
 
             final CountDownLatch messageLatch = new CountDownLatch(1);
 
@@ -252,7 +254,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH));
 
             messageLatch.await(1, TimeUnit.SECONDS);
             assertTrue("Redirect for this 3xx code is not supported. HandshakeException must be thrown.", false);
@@ -273,7 +275,7 @@ public class RedirectTest extends TestContainer {
         try {
             server = startServer(RedirectedEchoEndpoint.class);
 
-            for (HttpStatus httpstatus : statuses) {
+            for (HttpStatus httpstatus : STATUSES) {
                 testRedirectNotAllowed(httpstatus);
             }
         } finally {
@@ -287,8 +289,8 @@ public class RedirectTest extends TestContainer {
             AuthenticationException {
         HttpServer httpServer = null;
         try {
-            httpServer = startHttpRedirectionServer(REDIRECTION_PORT, httpStatus,
-                                                    "ws://localhost:8025/redirect-echo/echo");
+            httpServer = startHttpRedirectionServer(redirectionPort, httpStatus,
+                "ws://localhost:" + getPort() + "/redirect-echo/echo");
 
             final CountDownLatch messageLatch = new CountDownLatch(1);
 
@@ -315,7 +317,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH));
 
             messageLatch.await(1, TimeUnit.SECONDS);
             assertTrue("Redirect is not allowed. RedirectException must be thrown.", false);
@@ -336,7 +338,7 @@ public class RedirectTest extends TestContainer {
         try {
             server = startServer(RedirectedEchoEndpoint.class);
 
-            for (HttpStatus httpstatus : statuses) {
+            for (HttpStatus httpstatus : STATUSES) {
                 testRedirectNotAllowedByDefault(httpstatus);
             }
         } finally {
@@ -351,8 +353,8 @@ public class RedirectTest extends TestContainer {
         HttpServer httpServer = null;
         try {
 
-            httpServer = startHttpRedirectionServer(REDIRECTION_PORT, httpStatus,
-                                                    "ws://localhost:8025/redirect-echo/echo");
+            httpServer = startHttpRedirectionServer(redirectionPort, httpStatus,
+                "ws://localhost:" + getPort() + "/redirect-echo/echo");
 
             final CountDownLatch messageLatch = new CountDownLatch(1);
 
@@ -377,7 +379,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH));
 
             messageLatch.await(1, TimeUnit.SECONDS);
             assertTrue("Redirect is not allowed. RedirectException must be thrown.", false);
@@ -398,7 +400,7 @@ public class RedirectTest extends TestContainer {
         try {
             server = startServer(RedirectedEchoEndpoint.class);
 
-            for (HttpStatus httpstatus : statuses) {
+            for (HttpStatus httpstatus : STATUSES) {
                 testRedirectLoop(httpstatus);
             }
         } finally {
@@ -412,7 +414,7 @@ public class RedirectTest extends TestContainer {
             AuthenticationException {
         HttpServer httpServer = null;
         try {
-            httpServer = startHttpRedirectionServer(REDIRECTION_PORT, httpStatus, REDIRECTION_URI + REDIRECTION_PATH);
+            httpServer = startHttpRedirectionServer(redirectionPort, httpStatus, redirectionUri + REDIRECTION_PATH);
 
             final CountDownLatch messageLatch = new CountDownLatch(1);
 
@@ -438,7 +440,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH));
 
             assertTrue("Redirect loop must cause RedirectException", false);
         } catch (DeploymentException e) {
@@ -458,7 +460,7 @@ public class RedirectTest extends TestContainer {
         try {
             server = startServer(RedirectedEchoEndpoint.class);
 
-            for (HttpStatus httpstatus : statuses) {
+            for (HttpStatus httpstatus : STATUSES) {
                 testMaxRedirectionExceed(httpstatus);
             }
         } finally {
@@ -472,18 +474,18 @@ public class RedirectTest extends TestContainer {
             AuthenticationException {
         HttpServer httpServer = null;
         try {
-            httpServer = createHttpServer(REDIRECTION_PORT);
-            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, REDIRECTION_URI
+            httpServer = createHttpServer(redirectionPort);
+            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, redirectionUri
                     + REDIRECTION_PATH + 1), REDIRECTION_PATH + 0);
-            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, REDIRECTION_URI
+            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, redirectionUri
                     + REDIRECTION_PATH + 2), REDIRECTION_PATH + 1);
-            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, REDIRECTION_URI
+            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, redirectionUri
                     + REDIRECTION_PATH + 3), REDIRECTION_PATH + 2);
-            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, REDIRECTION_URI
+            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, redirectionUri
                     + REDIRECTION_PATH + 4), REDIRECTION_PATH + 3);
-            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, REDIRECTION_URI
+            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, redirectionUri
                     + REDIRECTION_PATH + 5), REDIRECTION_PATH + 4);
-            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, REDIRECTION_URI
+            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, redirectionUri
                     + REDIRECTION_PATH + 6), REDIRECTION_PATH + 5);
             httpServer.start();
 
@@ -508,7 +510,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH + 0));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH + 0));
 
             assertTrue("Too much redirection must cause RedirectException", false);
         } catch (DeploymentException e) {
@@ -527,7 +529,7 @@ public class RedirectTest extends TestContainer {
         try {
             server = startServer(RedirectedEchoEndpoint.class);
 
-            for (HttpStatus httpstatus : statuses) {
+            for (HttpStatus httpstatus : STATUSES) {
                 testMaxRedirectionConfig(httpstatus);
             }
         } finally {
@@ -541,12 +543,12 @@ public class RedirectTest extends TestContainer {
             AuthenticationException {
         HttpServer httpServer = null;
         try {
-            httpServer = createHttpServer(REDIRECTION_PORT);
-            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, REDIRECTION_URI
+            httpServer = createHttpServer(redirectionPort);
+            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, redirectionUri
                     + REDIRECTION_PATH + 1), REDIRECTION_PATH + 0);
-            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, REDIRECTION_URI
+            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, redirectionUri
                     + REDIRECTION_PATH + 2), REDIRECTION_PATH + 1);
-            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, REDIRECTION_URI
+            httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, redirectionUri
                     + REDIRECTION_PATH + 3), REDIRECTION_PATH + 2);
             httpServer.start();
 
@@ -573,7 +575,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH + 0));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH + 0));
 
             assertTrue("Too much redirection must cause RedirectException", false);
         } catch (DeploymentException e) {
@@ -592,7 +594,7 @@ public class RedirectTest extends TestContainer {
         try {
             server = startServer(RedirectedEchoEndpoint.class);
 
-            for (HttpStatus httpstatus : statuses) {
+            for (HttpStatus httpstatus : STATUSES) {
                 testMaxRedirectionConfigNeg(httpstatus);
             }
         } finally {
@@ -600,7 +602,7 @@ public class RedirectTest extends TestContainer {
                 server.stop();
             }
         }
-        for (HttpStatus httpstatus : statuses) {
+        for (HttpStatus httpstatus : STATUSES) {
             testMaxRedirectionConfigNeg(httpstatus);
         }
     }
@@ -611,9 +613,9 @@ public class RedirectTest extends TestContainer {
         HttpServer httpServer = null;
         try {
 
-            httpServer = createHttpServer(REDIRECTION_PORT);
+            httpServer = createHttpServer(redirectionPort);
             httpServer.getServerConfiguration().addHttpHandler(
-                    new RedirectHandler(httpStatus, REDIRECTION_URI + REDIRECTION_PATH + 1), REDIRECTION_PATH + 0);
+                    new RedirectHandler(httpStatus, redirectionUri + REDIRECTION_PATH + 1), REDIRECTION_PATH + 0);
             httpServer.start();
 
             final ClientManager client = createClient();
@@ -639,7 +641,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH + 0));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH + 0));
 
             assertTrue("Too much redirection must cause RedirectException", false);
         } catch (DeploymentException e) {
@@ -658,7 +660,7 @@ public class RedirectTest extends TestContainer {
         try {
             server = startServer(RedirectedEchoEndpoint.class);
 
-            for (HttpStatus httpstatus : statuses) {
+            for (HttpStatus httpstatus : STATUSES) {
                 testRedirectMissingLocation(httpstatus);
             }
         } finally {
@@ -674,7 +676,7 @@ public class RedirectTest extends TestContainer {
         HttpServer httpServer = null;
         try {
 
-            httpServer = createHttpServer(REDIRECTION_PORT);
+            httpServer = createHttpServer(redirectionPort);
             httpServer.getServerConfiguration().addHttpHandler(new BadRedirectHandler(httpStatus), REDIRECTION_PATH);
             httpServer.start();
 
@@ -700,7 +702,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH));
 
             assertTrue("Missing location must cause RedirectException", false);
         } catch (DeploymentException e) {
@@ -719,7 +721,7 @@ public class RedirectTest extends TestContainer {
         try {
             server = startServer(RedirectedEchoEndpoint.class);
 
-            for (HttpStatus httpstatus : statuses) {
+            for (HttpStatus httpstatus : STATUSES) {
                 testRedirectEmptyLocation(httpstatus);
             }
         } finally {
@@ -735,7 +737,7 @@ public class RedirectTest extends TestContainer {
         HttpServer httpServer = null;
         try {
 
-            httpServer = createHttpServer(REDIRECTION_PORT);
+            httpServer = createHttpServer(redirectionPort);
             httpServer.getServerConfiguration().addHttpHandler(new RedirectHandler(httpStatus, ""), REDIRECTION_PATH);
             httpServer.start();
 
@@ -761,7 +763,7 @@ public class RedirectTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create(REDIRECTION_URI + REDIRECTION_PATH));
+            }, cec, URI.create(redirectionUri + REDIRECTION_PATH));
 
             assertTrue("Missing location must cause RedirectException", false);
         } catch (DeploymentException e) {

--- a/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/RetryAfterTest.java
+++ b/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/RetryAfterTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2021 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -57,9 +58,9 @@ import static org.junit.Assert.*;
  */
 public class RetryAfterTest extends TestContainer {
 
-    private static final int REDIRECTION_PORT = 8026;
     private static final HttpStatus SERVICE_UNAVAILABLE = HttpStatus.SERVICE_UNAVAILABLE_503;
     private static final String CONTEXT_ROOT = "/retry-after-echo";
+    private final int redirectionPort = getPort() + 1;
 
     public RetryAfterTest() {
         setContextPath(CONTEXT_ROOT);
@@ -104,9 +105,8 @@ public class RetryAfterTest extends TestContainer {
         HttpServer httpServer = null;
         try {
 
-            httpServer = startHttpServer(
-                    REDIRECTION_PORT,
-                    new MultipleRetryAfterHandler(1, retryAfter, "ws://localhost:8025/retry-after-echo/echo"));
+            httpServer = startHttpServer(redirectionPort,
+                new MultipleRetryAfterHandler(1, retryAfter, "ws://localhost:" + getPort() + "/retry-after-echo/echo"));
 
             final ClientManager client = ClientManager.createClient();
             final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
@@ -134,7 +134,7 @@ public class RetryAfterTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create("ws://localhost:8026/retry-after-echo/echo"));
+            }, cec, URI.create("ws://localhost:" + redirectionPort + "/retry-after-echo/echo"));
 
             assertTrue("Message has not been received", messageLatch.await(1, TimeUnit.SECONDS));
         } finally {
@@ -263,10 +263,8 @@ public class RetryAfterTest extends TestContainer {
         HttpServer httpServer = null;
         try {
 
-            httpServer = startHttpServer(
-                    REDIRECTION_PORT,
-                    new MultipleRetryAfterHandler(numberOfRetries, retryAfter,
-                                                  "ws://localhost:8025/retry-after-echo/echo"));
+            httpServer = startHttpServer(redirectionPort, new MultipleRetryAfterHandler(numberOfRetries, retryAfter,
+                "ws://localhost:" + getPort() + "/retry-after-echo/echo"));
 
             final ClientManager client = ClientManager.createClient();
             final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
@@ -293,7 +291,7 @@ public class RetryAfterTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create("ws://localhost:8026/retry-after-echo/echo"));
+            }, cec, URI.create("ws://localhost:" + redirectionPort + "/retry-after-echo/echo"));
 
             fail("Connection to the endpoint should fail");
         } catch (Exception e) {
@@ -319,9 +317,8 @@ public class RetryAfterTest extends TestContainer {
         HttpServer httpServer = null;
         try {
 
-            httpServer = startHttpServer(
-                    REDIRECTION_PORT, new MultipleRetryAfterHandler(numberOfRetries, retryAfter,
-                                                                    "ws://localhost:8025/retry-after-echo/echo"));
+            httpServer = startHttpServer(redirectionPort, new MultipleRetryAfterHandler(numberOfRetries, retryAfter,
+                "ws://localhost:" + getPort() + "/retry-after-echo/echo"));
 
             final ClientManager client = ClientManager.createClient();
             final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
@@ -348,7 +345,7 @@ public class RetryAfterTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create("ws://localhost:8026/retry-after-echo/echo"));
+            }, cec, URI.create("ws://localhost:" + redirectionPort + "/retry-after-echo/echo"));
 
             fail("Connection to the endpoint should fail");
         } catch (Exception e) {
@@ -387,9 +384,8 @@ public class RetryAfterTest extends TestContainer {
         HttpServer httpServer = null;
         try {
 
-            httpServer = startHttpServer(
-                    REDIRECTION_PORT,
-                    new MultipleRetryAfterHandler(2, retryAfter, "ws://localhost:8025/retry-after-echo/echo"));
+            httpServer = startHttpServer(redirectionPort,
+                new MultipleRetryAfterHandler(2, retryAfter, "ws://localhost:" + getPort() + "/retry-after-echo/echo"));
 
             final ClientManager client = ClientManager.createClient();
             final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
@@ -417,7 +413,7 @@ public class RetryAfterTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create("ws://localhost:8026/retry-after-echo/echo"));
+            }, cec, URI.create("ws://localhost:" + redirectionPort + "/retry-after-echo/echo"));
 
             assertTrue("Message has not been received", messageLatch.await(1, TimeUnit.SECONDS));
         } finally {
@@ -448,9 +444,8 @@ public class RetryAfterTest extends TestContainer {
         HttpServer httpServer = null;
         try {
 
-            httpServer = startHttpServer(
-                    REDIRECTION_PORT, new MultipleRetryAfterHandler(6, retryAfter,
-                                                                    "ws://localhost:8025/retry-after-echo/echo"));
+            httpServer = startHttpServer(redirectionPort,
+                new MultipleRetryAfterHandler(6, retryAfter, "ws://localhost:" + getPort() + "/retry-after-echo/echo"));
 
             final ClientManager client = ClientManager.createClient();
             final ClientEndpointConfig cec = ClientEndpointConfig.Builder.create().build();
@@ -492,7 +487,7 @@ public class RetryAfterTest extends TestContainer {
                         // do nothing
                     }
                 }
-            }, cec, URI.create("ws://localhost:8026/retry-after-echo/echo"));
+            }, cec, URI.create("ws://localhost:" + redirectionPort + "/retry-after-echo/echo"));
 
             assertTrue("Message has not been received", messageLatch.await(1, TimeUnit.SECONDS));
             assertTrue("User-defined ReconnectHandler was not called", reconnectHandlerLatch.await(1, TimeUnit

--- a/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/SameHeadersOnClientTest.java
+++ b/tests/e2e/non-deployable/src/test/java/org/glassfish/tyrus/test/e2e/non_deployable/SameHeadersOnClientTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -81,7 +82,7 @@ public class SameHeadersOnClientTest extends TestContainer {
                         responseLatch.countDown();
                     }
                 }
-            }).build(), URI.create("ws://localhost:8025/testSameHeader"));
+            }).build(), URI.create("ws://localhost:" + getPort() + "/testSameHeader"));
 
             assertTrue(responseLatch.await(5, TimeUnit.SECONDS));
         } catch (Exception e) {
@@ -97,6 +98,7 @@ public class SameHeadersOnClientTest extends TestContainer {
     private HttpServer getHandshakeServer() throws IOException {
         HttpServer server = HttpServer.createSimpleServer("/testSameHeader", getHost(), getPort());
         server.getServerConfiguration().addHttpHandler(new HttpHandler() {
+            @Override
             public void service(Request request, Response response) throws Exception {
                 response.setStatus(101);
 

--- a/tests/e2e/standard-config/src/test/java/org/glassfish/tyrus/test/standard_config/ClientExecutorsManagementTest.java
+++ b/tests/e2e/standard-config/src/test/java/org/glassfish/tyrus/test/standard_config/ClientExecutorsManagementTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -56,6 +57,8 @@ import static org.junit.Assert.fail;
  * @author Petr Janouch
  */
 public class ClientExecutorsManagementTest extends TestContainer {
+
+    private final int port = getPort() + 1;
 
     /**
      * Test basic executor services life cycle.
@@ -159,8 +162,8 @@ public class ClientExecutorsManagementTest extends TestContainer {
             HttpServer lazyServer = getLazyServer(blockResponseLatch);
             clientManager.getProperties().put(ClientProperties.HANDSHAKE_TIMEOUT, 2000);
             try {
-                clientManager.connectToServer(
-                        AnnotatedClientEndpoint.class, URI.create("ws://localhost:8026/lazyServer"));
+                clientManager.connectToServer(AnnotatedClientEndpoint.class,
+                    URI.create("ws://localhost:" + port + "/lazyServer"));
                 fail();
             } catch (Exception e) {
                 // exception is expected
@@ -342,9 +345,10 @@ public class ClientExecutorsManagementTest extends TestContainer {
     }
 
     private HttpServer getLazyServer(final CountDownLatch blockResponseLatch) throws IOException {
-        HttpServer server = HttpServer.createSimpleServer("/lazyServer", "localhost", 8026);
+        HttpServer server = HttpServer.createSimpleServer("/lazyServer", "localhost", port);
         server.getServerConfiguration().addHttpHandler(
                 new HttpHandler() {
+                    @Override
                     public void service(Request request, Response response) throws Exception {
                         blockResponseLatch.await(1, TimeUnit.MINUTES);
                     }

--- a/tests/servlet/debug/src/test/java/org/glassfish/tyrus/tests/servlet/debug/DebugSampleTest.java
+++ b/tests/servlet/debug/src/test/java/org/glassfish/tyrus/tests/servlet/debug/DebugSampleTest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2014, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -219,7 +220,8 @@ public class DebugSampleTest extends TestContainer {
                     onOpenLatch.countDown();
                 }
 
-            }, ClientEndpointConfig.Builder.create().build(), URI.create("ws://localhost:8025/testAuthentication"));
+            }, ClientEndpointConfig.Builder.create().build(),
+                URI.create("ws://localhost:" + getPort() + "/testAuthentication"));
 
             assertTrue(onOpenLatch.await(3, TimeUnit.SECONDS));
         } catch (Exception e) {

--- a/tests/servlet/embedded-glassfish-test/pom.xml
+++ b/tests/servlet/embedded-glassfish-test/pom.xml
@@ -152,7 +152,7 @@
                             </includes>
                             <dependenciesToScan>org.glassfish.tyrus.tests.servlet:tyrus-tests-servlet-embedded-gf</dependenciesToScan>
                             <systemPropertyVariables>
-                                <tyrus.test.port>8080</tyrus.test.port>
+                                <tyrus.test.port>${tyrus.test.port}</tyrus.test.port>
                                 <junit.log.traceflag>true</junit.log.traceflag>
                             </systemPropertyVariables>
                             <environmentVariables>

--- a/tests/servlet/embedded-glassfish-test/pom.xml
+++ b/tests/servlet/embedded-glassfish-test/pom.xml
@@ -31,9 +31,9 @@
     <name>Tyrus Servlet Tests on Glassfish</name>
 
     <properties>
-        <glassfish.home>${project.build.directory}/glassfish8</glassfish.home>
+        <glassfish.directoryName>glassfish7</glassfish.directoryName>
+        <glassfish.home>${project.build.directory}/${glassfish.directoryName}</glassfish.home>
         <modules.dir>${glassfish.home}/glassfish/modules</modules.dir>
-<!--        <websocket-api.version>2.1.0-SNAPSHOT</websocket-api.version>-->
         <glassfish.container.version>${glassfish.version}</glassfish.container.version>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
     </properties>
@@ -96,20 +96,14 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>1.7.0.Alpha10</version>
+            <version>1.10.0.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-glassfish-managed-6</artifactId>
-            <version>1.0.0.Alpha1</version>
+            <groupId>ee.omnifish.arquillian</groupId>
+            <artifactId>arquillian-glassfish-server-managed</artifactId>
+            <version>2.1.2</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.glassfish.hk2</groupId>
-                    <artifactId>hk2-locator</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2</groupId>
@@ -152,12 +146,11 @@
                             </includes>
                             <dependenciesToScan>org.glassfish.tyrus.tests.servlet:tyrus-tests-servlet-embedded-gf</dependenciesToScan>
                             <systemPropertyVariables>
-                                <tyrus.test.port>${tyrus.test.port}</tyrus.test.port>
+                                <glassfish.home>${glassfish.home}</glassfish.home>
+                                <glassfish.httpPort>${tyrus.test.port}</glassfish.httpPort>
+                                <glassfish.version>${glassfish.container.version}</glassfish.version>
                                 <junit.log.traceflag>true</junit.log.traceflag>
                             </systemPropertyVariables>
-                            <environmentVariables>
-                                <GLASSFISH_HOME>${glassfish.home}</GLASSFISH_HOME>
-                            </environmentVariables>
                         </configuration>
                     </execution>
                 </executions>

--- a/tests/servlet/embedded-glassfish-test/src/test/java/org/glassfish/tyrus/tests/servlet/embedded/SSLTestIT.java
+++ b/tests/servlet/embedded-glassfish-test/src/test/java/org/glassfish/tyrus/tests/servlet/embedded/SSLTestIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -18,15 +19,8 @@ package org.glassfish.tyrus.tests.servlet.embedded;
 
 import jakarta.websocket.ClientEndpointConfig;
 import jakarta.websocket.DeploymentException;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit5.ArquillianExtension;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,6 +31,16 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ArquillianExtension.class)
 public class SSLTestIT extends ServletTestBase {
@@ -74,7 +78,7 @@ public class SSLTestIT extends ServletTestBase {
     @Override
     protected ClientEndpointConfig createClientEndpointConfig() throws DeploymentException {
         final String password = "changeit";
-        final String keyStore = System.getenv("GLASSFISH_HOME") + "/glassfish/domains/domain1/config/keystore.jks";
+        final File keyStore = getKeyStoreFile();
 
         try {
             KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
@@ -101,5 +105,18 @@ public class SSLTestIT extends ServletTestBase {
                 | NoSuchAlgorithmException | KeyManagementException e) {
             throw new DeploymentException(e.getMessage(), e);
         }
+    }
+
+    private File getKeyStoreFile() throws DeploymentException {
+        final File cfgDir = new File(System.getProperty("glassfish.home") + "/glassfish/domains/domain1/config");
+        final File pkcsFile = new File(cfgDir, "keystore.p12");
+        if (pkcsFile.exists()) {
+            return pkcsFile;
+        }
+        final File jksFile = new File(cfgDir, "keystore.jks");
+        if (jksFile.exists()) {
+            return jksFile;
+        }
+        throw new DeploymentException("Could not find supported keystore file in directory " + cfgDir);
     }
 }

--- a/tests/servlet/embedded-glassfish-test/src/test/java/org/glassfish/tyrus/tests/servlet/embedded/ServletTestBase.java
+++ b/tests/servlet/embedded-glassfish-test/src/test/java/org/glassfish/tyrus/tests/servlet/embedded/ServletTestBase.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
  * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -49,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public abstract class ServletTestBase {
 
     private static final String defaultHost = "localhost";
-    private static final int defaultPort = 8025;
+    private static final int defaultPort = Integer.getInteger("glassfish.httpPort", 8025);
     private String contextPath;
 
     protected abstract String getScheme();
@@ -226,7 +227,7 @@ public abstract class ServletTestBase {
      * @return port used for creating remote endpoint {@link URI}.
      */
     protected int getPort() {
-        final String port = System.getProperty("tyrus.test.port");
+        final String port = System.getProperty("glassfish.httpPort");
         if (port != null) {
             try {
                 return Integer.parseInt(port);


### PR DESCRIPTION
### Review

* You can do the review per commit. 
* I could create a standalone PR for every change, however then I would not be able to test them as branch 2.x failed locally without changes.
* Interesting: Claude AI was wrong suggesting range `[3.0,)`. StackOverflow is right: https://stackoverflow.com/a/8354987/375449

### Fixes

* Some tests used hardcoded ports and did not respect the overridden value

### Upgrades

* Felix plugin - there was a comment which was probably valid for 2.1.x, but was not relevant any more.
* Jetty tests were using Jetty 9, while there is already Jetty 11 available.
* GlassFish tests were using GlassFish 8JDK17M5 which fails to collect dependencies as the staging is already gone. So I switched to 7.1.0 and tested also local 8.0.0-SNAPSHOT (however you can use also snapshot from Maven Central Snapshots temporarily), 8.0.0-M15, 8.0.0-M14.
* Arquillian used in GF tests as new version is more reliable and robust.

### Change

* As we are closing to Grizzly 5.0.0 release, we have found out that Tyrus is not compatible with major Grizzly version change in the OSGI environment. So I removed the upper bound.
* After release of 5.0.0, Tyrus can simply update the dependency. Same with GlassFish 8.0.0.

### Testing

* I used Temurin JDK 25 in all cases.

Grizzly 5.0.0-SNAPSHOT + GlassFish 8.0.0-SNAPSHOT
```
mvn clean install -Dtyrus.test.port=12348 -Dtyrus.test.port2=12349 -Dglassfish.version=8.0.0-SNAPSHOT -Dglassfish.directoryName=glassfish8 -Dgrizzly.version=5.0.0-SNAPSHOT
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:05 min
[INFO] Finished at: 2026-01-12T22:54:12+01:00
[INFO] ------------------------------------------------------------------------
```

Grizzly 4.0.2 + GlassFish 7.1.0 (defaults)
```
mvn clean install -Dtyrus.test.port=12348 -Dtyrus.test.port2=12349
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:18 min
[INFO] Finished at: 2026-01-12T23:05:38+01:00
[INFO] ------------------------------------------------------------------------
```

Grizzly 4.0.2 + GlassFish 8.0.0-SNAPSHOT
```
mvn clean install -Dtyrus.test.port=12348 -Dtyrus.test.port2=12349 -Dglassfish.version=8.0.0-SNAPSHOT -Dglassfish.directoryName=glassfish8
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  03:04 min
[INFO] Finished at: 2026-01-12T22:57:45+01:00
[INFO] ------------------------------------------------------------------------
```

There are no tests targeting the OSGI compatibility, so I ran also GlassFish's own tests integrating Tyrus and Grizzly snapshots. After I fixed the range to `"3"` the failing test passed (see the StackOverflow reference).
```
mvn clean install -T4C -Pfastest &&  mvn clean install -rf :glassfish-itest-tools
...
