### PR TITLE
Configuration for deployment to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,53 @@
         <tag>HEAD</tag>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <releases>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+        <repository>
+            <id>central-portal-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <checksumPolicy>fail</checksumPolicy>
+            </snapshots>
+        </repository>
+    </repositories>
+
+    <!-- TODO: Can be removed after it would be removed from parent too -->
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <name>Disabled Sonatype Nexus</name>
+            <url>http://localhost</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <name>Disabled Sonatype Nexus</name>
+            <url>http://localhost</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </distributionManagement>
+
     <licenses>
         <license>
             <name>Eclipse Public License 2.0</name>
@@ -156,6 +203,11 @@
         <jar.updater.modules.skip>org.glassfish.tyrus.samples:*,*:*-project,*:tyrus-archetype*,*:*-documentation,org.glassfish.tyrus.tests:*e2e*,org.glassfish.tyrus.tests.servlet*:*,org.glassfish.tyrus.bundles:*,org.glassfish.tyrus.tests:*containers*</jar.updater.modules.skip>
 
         <tyrus.test.port>8025</tyrus.test.port>
+
+        <!-- Do not autopublish by default -->
+        <release.autopublish>false</release.autopublish>
+        <!-- By default block until everything is really published -->
+        <release.waitUntil>published</release.waitUntil>
     </properties>
 
     <modules>
@@ -362,6 +414,33 @@
                         </dependency>
                     </dependencies>
                 </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.7.0</version>
+                    <configuration>
+                        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>injected-nexus-deploy</id>
+                            <phase>none</phase>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.10.0</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <autoPublish>${release.autopublish}</autoPublish>
+                        <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
+                        <deploymentName>GlassFish Tyrus ${project.version}</deploymentName>
+                        <publishingServerId>central</publishingServerId>
+                        <waitUntil>${release.waitUntil}</waitUntil>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -485,6 +564,19 @@
     </build>
 
     <profiles>
+        <!-- See parent, maven release plugin uses this profile for the deployment -->
+        <profile>
+            <id>oss-release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- Initiates the release on Jenkins CI -->
         <profile>
             <id>release</id>
             <build>


### PR DESCRIPTION
If I would have committer rights, I would push this branch to the target repository, then tested it - deployments of snapshots don't cause much problems, with testing releases it is important to avoid automatic publishing, and it is good to have access to the Maven Central account managing the target namespace.

Daily deployments to snapshots would enable possibility to refer snapshots in any other projects, test them and complain BEFORE release of Tyrus. Or even temporarily cooperate on some breaking changes.

- [ ] Merge the branch or better create the copy of this branch in the target repository
- [ ] Create deploy-tyrus-snapshot job on the CI, see examples.
- [ ] Check and update all values in the configuration, carefully one by one.
- [ ] Run the new job against the branch and check everything is in order (first for the snapshot; the [release job](https://ci.eclipse.org/tyrus/job/tyrus-22x-release-new/configure) can be updated later, if even needed).
- [ ] Merge this PR
- [ ] Delete the experimental branch (copy of this in the target repository)

Examples: 
- https://ci.eclipse.org/glassfish/view/Release/job/shoal-deploy-snapshot/
- https://ci.eclipse.org/glassfish/view/Release/job/grizzly-deploy-snapshot/
- https://ci.eclipse.org/glassfish/view/Release/job/glassfish-deploy-snapshot/ 
